### PR TITLE
Add CI configuration file for JDK 1.8 builds

### DIFF
--- a/.github/workflows/jdk1.8.yml
+++ b/.github/workflows/jdk1.8.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml


### PR DESCRIPTION
Configure a github workflow to build CI-RT Web with JDK 1.8. The workflow acts as an additionally test for CI-RT Web.